### PR TITLE
Mapping base class obj attributes

### DIFF
--- a/pyzos/zos.py
+++ b/pyzos/zos.py
@@ -18,6 +18,7 @@ import time as _time
 import warnings as _warnings
 from pyzos.zosutils import (ZOSPropMapper as _ZOSPropMapper, 
                             replicate_methods as _replicate_methods,
+                            inheritance_dict as _inheritance_dict,
                             wrapped_zos_object as wrapped_zos_object)
 import pyzos.ddeclient as _dde
 
@@ -249,6 +250,9 @@ class OpticalSystem(object):
             if mode == 1:
                 self._iopticalsystem.MakeNonSequential()
             OpticalSystem._instantiated = True
+
+        ## Store base class object 
+        self._base_cls_name = _inheritance_dict.get('IOpticalSystem', None)
             
         ## activate PyZDDE if sync_ui requested
         if sync_ui and not OpticalSystem._dde_link:
@@ -270,7 +274,8 @@ class OpticalSystem(object):
             for ext in ext_dict:
                 if _os.path.exists(filename_bar_ext + ext):
                     _delete_file(filename_bar_ext + ext)
-        OpticalSystem._dde_link.zDDEClose()  ##TODO: FIX should probably have a reference count???
+        if OpticalSystem._dde_link:
+            OpticalSystem._dde_link.zDDEClose()  ##TODO: FIX should probably have a reference count???
         
     #%% UI sync machinery
     def zPushLens(self, update=None):

--- a/pyzos/zos.py
+++ b/pyzos/zos.py
@@ -260,6 +260,10 @@ class OpticalSystem(object):
         self._sync_ui_file = _get_sync_ui_filename() if sync_ui else None
         self._file_to_save_on_Save = None
         
+        ## patch methods from base calss of IOpticalSystem to the instance
+        if self._base_cls_name:
+            _replicate_methods(_comclient.CastTo(self._iopticalsystem, self._base_cls_name), self)
+
         ## patch methods from IOpticalSystem to the instance
         _replicate_methods(self._iopticalsystem, self)
 

--- a/pyzos/zos.py
+++ b/pyzos/zos.py
@@ -68,7 +68,6 @@ def _delete_file(fileName, n=10):
     return status
 
 
-
 #%% _PyZDDE class (stripped down)
 class _PyZDDE(object):
     """Class for communicating with Zemax using DDE"""
@@ -229,8 +228,11 @@ class OpticalSystem(object):
     _instantiated = False
     _pyzosapp = None
     _dde_link = None
+
+    # Patch managed properties of IOpticalSystem's base classes
+    # skipped for now ... IOpticalSystem doesn't have any base class (currently)
         
-    # Managed properties (prefix with 'p' to ease identification)
+    # Patch managed properties of ZOS IOpticalSystem
     pIsNonAxial = _ZOSPropMapper('_iopticalsystem', 'IsNonAxial')
     pMode = _ZOSPropMapper('_iopticalsystem', 'Mode')
     pNeedsSave = _ZOSPropMapper('_iopticalsystem', 'NeedsSave')
@@ -245,14 +247,14 @@ class OpticalSystem(object):
         if OpticalSystem._instantiated:
             self._iopticalsystem = OpticalSystem._pyzosapp.CreateNewSystem(mode) # wrapped object
         else:
-            OpticalSystem._pyzosapp = _PyZOSApp()               # wrapped object
+            OpticalSystem._pyzosapp = _PyZOSApp()                         # wrapped object
             self._iopticalsystem = OpticalSystem._pyzosapp.GetSystemAt(0) # PrimarySystem
             if mode == 1:
                 self._iopticalsystem.MakeNonSequential()
             OpticalSystem._instantiated = True
 
-        ## Store base class object 
-        self._base_cls_name = _inheritance_dict.get('IOpticalSystem', None)
+        ## Store ZOS IOpticalSystem's base class(es)
+        self._base_cls_list = _inheritance_dict.get('IOpticalSystem', None)
             
         ## activate PyZDDE if sync_ui requested
         if sync_ui and not OpticalSystem._dde_link:
@@ -260,11 +262,12 @@ class OpticalSystem(object):
         self._sync_ui_file = _get_sync_ui_filename() if sync_ui else None
         self._file_to_save_on_Save = None
         
-        ## patch methods from base calss of IOpticalSystem to the instance
-        if self._base_cls_name:
-            _replicate_methods(_comclient.CastTo(self._iopticalsystem, self._base_cls_name), self)
+        ## patch methods from base class of IOpticalSystem to the wrapped object
+        if self._base_cls_list:
+            for base_cls_name in self._base_cls_list:
+                _replicate_methods(_comclient.CastTo(self._iopticalsystem, base_cls_name), self)
 
-        ## patch methods from IOpticalSystem to the instance
+        ## patch methods from ZOS IOpticalSystem to the wrapped object
         _replicate_methods(self._iopticalsystem, self)
 
     # Provide a way to make property calls without the prefix p, but don't try to wrap the returned object            

--- a/pyzos/zos_obj_override/i_analyses_methods.py
+++ b/pyzos/zos_obj_override/i_analyses_methods.py
@@ -37,11 +37,5 @@ def New_FftMtf(self):
 def New_FftMtfMap(self):
     return _wrapped_zos_object(self._i_analyses.New_FftMtfMap())
 
-# Extra methods
-# -------------
-def zDummyI_AnalysesMethod1(self):
-    print('Dummy I_Analyses Method')
-
-def zDummyI_AnalysesMethod2(self):
-    print('Dummy I_Analyses Method')
-    
+# Custom methods
+# --------------

--- a/pyzos/zos_obj_override/ia__methods.py
+++ b/pyzos/zos_obj_override/ia__methods.py
@@ -20,17 +20,12 @@ def GetResults(self):
     return _wrapped_zos_object(self._ia_.GetResults())
 
 def GetSettings(self):
-    # the GetSettings() method of IA_ interface returns IAS_ interface object 
-    # which is the base class of all other settings interface. IAS_ contains a 
-    # set of methods intended to be inherited by the specialized settings classes
-    # such as IAS_FftMtf, IAS_FftMap, etc. 
-    # If we just return the IA_ interface only the common set of methods are available
-    # to the caller. In order to use the properties specific to a particular analysis
-    # the caller needs to cast the interface.
-    # If we merely cast the IAS_ object to the specialized interface in order to access
-    # the properties, then the common set of methods from the base class (IAS_) are no
-    # longer available. Thefore, we do the following to ensure that the returned 
-    # settings object has both the common set of methods and the specific properties.
+    # the IA_.GetSettings() returns IAS_ which is the base class of all other settings 
+    # objects such as IAS_FftMtf, IAS_FftMap, etc. The base-class IAS_ objects needs to be 
+    # "specialized" for a particular analysis using the _CastTo function. When we apply 
+    # CastTo(), the specialized objects "gain" the specific analysis functions and properties.
+    # before returning, when we invoke _wrapped_zos_object(), the base-class methods and 
+    # properties also gets patched. 
     
     settings_base = self._ia_.GetSettings()
     
@@ -64,9 +59,7 @@ def GetSettings(self):
         
     # create the settings object 
     settings = _wrapped_zos_object(settings)
-    
-    # add the common set of methods of the base settings interface  
-    _replicate_methods(srcObj=settings_base, dstObj=settings)
+
     return settings
 
 # Extra methods

--- a/pyzos/zos_obj_override/ilensdataeditor_methods.py
+++ b/pyzos/zos_obj_override/ilensdataeditor_methods.py
@@ -17,32 +17,10 @@ from pyzos.zosutils import wrapped_zos_object as _wrapped_zos_object
 
 # Overridden methods
 # ------------------
-# def AddRow(self):
-#     """Adds a new row at the end of the editor."""
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return _wrapped_zos_object(base_lde.AddRow())
-
-
-# def DeleteAllRows(self):
-#     """Deletes all rows from the current editor"""
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.DeleteAllRows()
-
-
-# def DeleteRowAt(self, pos):
-#     """Deletes a row at the specified index (0 to NumberOfRows-1)
-#     @pos : The index of the first row to remove
-#     """
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.DeleteRowAt(pos)
-
-# def DeleteRowsAt(self, pos, numOfRows):
-#     """Deletes one or more rows at the specified index (0 to NumberOfRows-1)
-#     @pos : The index of the first row to remove
-#     @numOfRows : The number of rows to remove
-#     """
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.DeleteRowsAt(pos, numOfRows)
+def AddRow(self):
+    """Adds a new row at the end of the editor."""
+    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+    return _wrapped_zos_object(base_lde.AddRow())
 
 def GetPupil(self):
     """Retrieve pupil data
@@ -58,12 +36,12 @@ def GetPupil(self):
     data = self._ilensdataeditor.GetPupil()
     return pupil_data(*data)
 
-# def GetRowAt(self, pos):
-#     """Gets the row at the specified index (0 to NumberOfRows-1).
-#     @pos : The row index.
-#     """
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return _wrapped_zos_object(base_lde.GetRowAt(pos))
+def GetRowAt(self, pos):
+    """Gets the row at the specified index (0 to NumberOfRows-1).
+    @pos : The row index.
+    """
+    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+    return _wrapped_zos_object(base_lde.GetRowAt(pos))
 
 def GetSurfaceAt(self, surfNum):
     """Gets the data for the specified surface."""
@@ -72,29 +50,6 @@ def GetSurfaceAt(self, surfNum):
 
 # Overridden properties
 # ---------------------
-# @property
-# def pEditor(self):
-#     """Gets the type of editor instance"""
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.Editor
-
-# @property
-# def pMaxColumn(self):
-#     """The maximum column index that can be used in calls to GetCellAt()"""
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.MaxColumn
-
-# @property
-# def pMinColumn(self):
-#     """The minimum column index that can be used in calls to GetCellAt()"""
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.MinColumn
-
-# @property
-# def pNumberOfRows(self):
-#     """Gets the number of rows in this editor"""
-#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-#     return base_lde.NumberOfRows
 
 
 # Extra methods

--- a/pyzos/zos_obj_override/ilensdataeditor_methods.py
+++ b/pyzos/zos_obj_override/ilensdataeditor_methods.py
@@ -17,32 +17,32 @@ from pyzos.zosutils import wrapped_zos_object as _wrapped_zos_object
 
 # Overridden methods
 # ------------------
-def AddRow(self):
-    """Adds a new row at the end of the editor."""
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return _wrapped_zos_object(base_lde.AddRow())
+# def AddRow(self):
+#     """Adds a new row at the end of the editor."""
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return _wrapped_zos_object(base_lde.AddRow())
 
 
-def DeleteAllRows(self):
-    """Deletes all rows from the current editor"""
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.DeleteAllRows()
+# def DeleteAllRows(self):
+#     """Deletes all rows from the current editor"""
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.DeleteAllRows()
 
 
-def DeleteRowAt(self, pos):
-    """Deletes a row at the specified index (0 to NumberOfRows-1)
-    @pos : The index of the first row to remove
-    """
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.DeleteRowAt(pos)
+# def DeleteRowAt(self, pos):
+#     """Deletes a row at the specified index (0 to NumberOfRows-1)
+#     @pos : The index of the first row to remove
+#     """
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.DeleteRowAt(pos)
 
-def DeleteRowsAt(self, pos, numOfRows):
-    """Deletes one or more rows at the specified index (0 to NumberOfRows-1)
-    @pos : The index of the first row to remove
-    @numOfRows : The number of rows to remove
-    """
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.DeleteRowsAt(pos, numOfRows)
+# def DeleteRowsAt(self, pos, numOfRows):
+#     """Deletes one or more rows at the specified index (0 to NumberOfRows-1)
+#     @pos : The index of the first row to remove
+#     @numOfRows : The number of rows to remove
+#     """
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.DeleteRowsAt(pos, numOfRows)
 
 def GetPupil(self):
     """Retrieve pupil data
@@ -58,12 +58,12 @@ def GetPupil(self):
     data = self._ilensdataeditor.GetPupil()
     return pupil_data(*data)
 
-def GetRowAt(self, pos):
-    """Gets the row at the specified index (0 to NumberOfRows-1).
-    @pos : The row index.
-    """
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return _wrapped_zos_object(base_lde.GetRowAt(pos))
+# def GetRowAt(self, pos):
+#     """Gets the row at the specified index (0 to NumberOfRows-1).
+#     @pos : The row index.
+#     """
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return _wrapped_zos_object(base_lde.GetRowAt(pos))
 
 def GetSurfaceAt(self, surfNum):
     """Gets the data for the specified surface."""
@@ -72,29 +72,29 @@ def GetSurfaceAt(self, surfNum):
 
 # Overridden properties
 # ---------------------
-@property
-def pEditor(self):
-    """Gets the type of editor instance"""
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.Editor
+# @property
+# def pEditor(self):
+#     """Gets the type of editor instance"""
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.Editor
 
-@property
-def pMaxColumn(self):
-    """The maximum column index that can be used in calls to GetCellAt()"""
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.MaxColumn
+# @property
+# def pMaxColumn(self):
+#     """The maximum column index that can be used in calls to GetCellAt()"""
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.MaxColumn
 
-@property
-def pMinColumn(self):
-    """The minimum column index that can be used in calls to GetCellAt()"""
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.MinColumn
+# @property
+# def pMinColumn(self):
+#     """The minimum column index that can be used in calls to GetCellAt()"""
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.MinColumn
 
-@property
-def pNumberOfRows(self):
-    """Gets the number of rows in this editor"""
-    base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
-    return base_lde.NumberOfRows
+# @property
+# def pNumberOfRows(self):
+#     """Gets the number of rows in this editor"""
+#     base_lde = _CastTo(self._ilensdataeditor, 'IEditor')
+#     return base_lde.NumberOfRows
 
 
 # Extra methods

--- a/pyzos/zos_obj_override/ilocaloptimization_methods.py
+++ b/pyzos/zos_obj_override/ilocaloptimization_methods.py
@@ -16,10 +16,3 @@ from pyzos.zosutils import wrapped_zos_object as _wrapped_zos_object
 
 # Overridden methods
 # ------------------
-def RunAndWaitForCompletion(self):
-    base_tool = _CastTo(self._ilocaloptimization, 'ISystemTool')
-    return base_tool.RunAndWaitForCompletion()
-
-def Close(self):
-    base_tool = _CastTo(self._ilocaloptimization, 'ISystemTool')
-    return base_tool.Close()

--- a/pyzos/zos_obj_override/imeritfunctioneditor_methods.py
+++ b/pyzos/zos_obj_override/imeritfunctioneditor_methods.py
@@ -22,32 +22,6 @@ def AddRow(self):
     base_mfe = _CastTo(self._imeritfunctioneditor, 'IEditor')
     return _wrapped_zos_object(base_mfe.AddRow())
 
-def DeleteAllRows(self):
-    """Deletes all rows from the current editor"""
-    base_mfe = _CastTo(self._imeritfunctioneditor, 'IEditor')
-    return base_mfe.DeleteAllRows()
-
-def DeleteRowAt(self, pos):
-    """Deletes a row at the specified index (0 to NumberOfRows-1)
-    @pos : The index of the first row to remove
-    """
-    base_mfe = _CastTo(self._imeritfunctioneditor, 'IEditor')
-    return base_mfe.DeleteRowAt(pos)
-
-def DeleteRowsAt(self, pos, numOfRows):
-    """Deletes one or more rows at the specified index (0 to NumberOfRows-1)
-    @pos : The index of the first row to remove
-    @numOfRows : The number of rows to remove
-    """
-    base_mfe = _CastTo(self._imeritfunctioneditor, 'IEditor')
-    return base_mfe.DeleteRowsAt(pos, numOfRows)
-
-def InsertRowAt(self, pos):
-    """Inserts a new row at the specified index (0 to NumberOfRows). 
-    @pos : The new row index.
-    """
-    base_mfe = _CastTo(self._imeritfunctioneditor, 'IEditor')
-    return base_mfe.InsertRowAt(pos)
 
 def GetRowAt(self, pos):
     """Gets the row at the specified index (0 to NumberOfRows-1).

--- a/pyzos/zosutils.py
+++ b/pyzos/zosutils.py
@@ -183,7 +183,8 @@ def wrapped_zos_object(zos_obj):
     Class = managed_wrapper_class_factory(zos_obj)
     return Class(zos_obj)
 
-#%% ZOS object inheritance relationships
+#%% ZOS object inheritance relationships (only those ZOS objects are entered that has a base class)
+# unfortunately this dict has to be created manually referring to the ZOS-API documentation
 inheritance_dict = {
     ## IEditor Interface - base interface for all 5 editors
     'ILensDataEditor' : 'IEditor',
@@ -193,8 +194,25 @@ inheritance_dict = {
     'IToleranceDataEditor' : 'IEditor',
     ## IAS_ Interface - base class for all analysis settings interfaces
     # Aberrations interface settings
+    'IAS_FieldCurvatureAndDistortion' : 'IAS_',
+    'IAS_FocalShiftDiagram' : 'IAS_',
+    'IAS_GridDistortion' : 'IAS_',
+    'IAS_LateralColor' : 'IAS_',
+    'IAS_LongitudinalAberration' : 'IAS_',
+    'IAS_RayTrace' : 'IAS_',
+    'IAS_SeidelCoefficients' : 'IAS_',
+    'IAS_SeidelDiagram' : 'IAS_',
+    'IAS_ZernikeAnnularCoefficients' : 'IAS_',
+    'IAS_ZernikeCoefficientsVsField' : 'IAS_',
+    'IAS_ZernikeFringeCoefficients' : 'IAS_',
+    'IAS_ZernikeStandardCoefficients' : 'IAS_',
     # EncircledEnergy interface settings
+    'IAS_DiffractionEncircledEnergy' : 'IAS_',
+    'IAS_ExtendedSourceEncircledEnergy' : 'IAS_',
+    'IAS_GeometricEncircledEnergy' : 'IAS_',
+    'IAS_GeometricLineEdgeSpread' : 'IAS_',
     # Fans interface settings
+    'IAS_Fan' : 'IAS_',
     # Mtf interface settings
     'IAS_FftMtf' : 'IAS_',
     'IAS_FftMtfMap' : 'IAS_',
@@ -210,11 +228,53 @@ inheritance_dict = {
     'IAS_HuygensSurfaceMtf' : 'IAS_',
     'IAS_HuygensThroughFocusMtf' : 'IAS_',
     # Psf interface settings
+    'IAS_FftPsf' : 'IAS_',
+    'IAS_FftPsfCrossSection' : 'IAS_',
+    'IAS_FftPsfLineEdgeSpread' : 'IAS_',
+    'IAS_HuygensPsf' : 'IAS_',
+    'IAS_HuygensPsfCrossSection' : 'IAS_',
     # RayTracing interface settings 
+    'IAS_DetectorViewer' : 'IAS_',
     # RMS interface settings
+    'IAS_RMSField' : 'IAS_',
+    'IAS_RMSFieldMap' : 'IAS_',
+    'IAS_RMSFocus' : 'IAS_',
+    'IAS_RMSLambdaDiagram' : 'IAS_',
     # Spot interface settings
+    'IAS_Spot' : 'IAS_',
     # Surface interface settings
+    'IAS_SurfaceCurvature' : 'IAS_',
+    'IAS_SurfaceCurvatureCross' : 'IAS_',
+    'IAS_SurfacePhase' : 'IAS_',
+    'IAS_SurfacePhaseCross' : 'IAS_',
+    'IAS_SurfaceSag' : 'IAS_',
+    'IAS_SurfaceSagCross' : 'IAS_',
     # Wavefront interface settings
-
-
+    'IAS_Foucault' : 'IAS_',
+    ## IOpticalSystemTools Interface - base class for all system tools
+    'IBatchRayTrace' : 'ISystemTool',
+    'IConvertToNSCGroup' : 'ISystemTool',
+    'ICreateArchive' : 'ISystemTool',
+    'IExportCAD' : 'ISystemTool',
+    'IGlobalOptimization' : 'ISystemTool',
+    'IHammerOptimization' : 'ISystemTool',
+    'ILensCatalogs' : 'ISystemTool',
+    'ILightningTrace' : 'ISystemTool',
+    'ILocalOptimization' : 'ISystemTool',
+    'IMFCalculator' : 'ISystemTool',
+    'INSCRayTrace' : 'ISystemTool',
+    'IQuickAdjust' : 'ISystemTool',
+    'IQuickFocus' : 'ISystemTool',
+    'IRestoreArchive' : 'ISystemTool',
+    'IScale' : 'ISystemTool',
+    'ITolerancing' : 'ISystemTool',    
+    ## IWizard Interface - base interface for all wizards
+    'INSCWizard' : 'IWizard',
+    'INSCBitmapWizard' : 'INSCWizard',   # here is a 2-level inheritence 
+    'INSCOptimizationWizard' : 'INSCWizard', # here is a 2-level inheritence
+    'INSCRoadwayLightingWizard' : 'IWizard',
+    'IToleranceWizard' : 'IWizard', 
+    'INSCToleranceWizard': 'IToleranceWizard', # here is a 2-level inheritence
+    'ISEQToleranceWizard' : 'IToleranceWizard', # here is a 2-level inheritence
+    'ISEQOptimizationWizard' : 'IWizard',
 }


### PR DESCRIPTION
No hard coding (CastTo application) required to patch parent (and ancestor classes') methods and properties. They will automatically get patched to a ZOS object when the wrapped_zos_object() method is invoked.